### PR TITLE
Enable ansible-galaxy and custom.regex managers

### DIFF
--- a/base.json5
+++ b/base.json5
@@ -13,7 +13,9 @@
         "github-actions",
         "npm",
         "pip_requirements",
-        "poetry"
+        "poetry",
+        "ansible-galaxy",
+        "custom.regex"
     ],
     "packageRules": [
         // Separate group for Spring Boot and Cloud packages (one group because they have to be compatible versions)


### PR DESCRIPTION
## Summary
- Add `ansible-galaxy` and `custom.regex` to the `enabledManagers` allow-list.

## Why
`enabledManagers` is an allow-list — managers not listed are silently disabled. Two were missing:
- **`ansible-galaxy`** — manages collections/roles in `requirements.yml`. Without it, pinned collection versions (e.g. `kubernetes.core`) never get update PRs.
- **`custom.regex`** — required for any repo using `customManagers`. Without it, custom-managed deps are dropped.

This surfaced in `ub-k8s-helmcharts`, where Helm `chart_version` pins (annotated for the regex manager) and `kubernetes.core` were silently ignored — only `pip_requirements` and `github-actions` were getting PRs. Verified locally with `renovate --platform=local --dry-run=extract`: before, 7 deps (actions + pip only); after, 33 deps (incl. 25 charts + the collection).

`custom.regex` is a no-op for repos that don't define `customManagers`, so this is low-risk for other repos. `ansible-galaxy` will start producing collection-update PRs for repos with a `requirements.yml`.

## Test plan
- [ ] Confirm Renovate validates the config (no `disallowed`/`Invalid configuration` errors)
- [ ] After merge, confirm `ub-k8s-helmcharts` opens chart + collection PRs on the next run